### PR TITLE
Document container entrypoint behavior (closes #9)

### DIFF
--- a/.env.production.example
+++ b/.env.production.example
@@ -24,6 +24,17 @@ CSRF_TRUSTED_ORIGINS=https://example.com,https://www.example.com
 # Optional CORS (comma-separated). Leave empty if same-origin only.
 CORS_ALLOWED_ORIGINS=https://app.example.com
 
+# Container entrypoint (backend/entrypoint.sh) — used when running via Docker Compose.
+# Whether startup runs collectstatic, migrate, and createcachetable (on/off).
+# infra/docker-compose.prod.yml sets this to "on" for the backend service.
+DJANGO_MANAGE_MIGRATE=on
+# Optional first-deploy bootstrap admin (entrypoint only; not used by host-run manage.py).
+# Set real values in .env.production or your secret manager — never commit credentials.
+# Remove or unset after the admin exists; prefer manual createsuperuser when you have shell access.
+# DJANGO_SUPERUSER_USERNAME=admin
+# DJANGO_SUPERUSER_PASSWORD=change-me
+# DJANGO_SUPERUSER_EMAIL=admin@example.com
+
 # Database — Django reads DATABASE_URL only in non-production settings.
 DATABASE_URL=postgresql://db_user:db_password@postgres:5432/db_name
 

--- a/backend/README.md
+++ b/backend/README.md
@@ -40,7 +40,11 @@ Key variables in `.env.production`:
 - `REDIS_URL`, `CELERY_BROKER_URL`
 - `EMAIL_*` (production SMTP — not `ETHEREAL_*`)
 
-Production does **not** read `DATABASE_URL` or `DB_HOST`/`DB_PORT`. The container entrypoint waits on `POSTGRES_HOST` before migrations.
+Production does **not** read `DATABASE_URL` or `DB_HOST`/`DB_PORT`.
+
+### Container entrypoint
+
+`backend/entrypoint.sh` runs before the app in Docker. It polls `POSTGRES_HOST`/`POSTGRES_PORT` until Postgres accepts connections (Compose `depends_on` does not guarantee readiness). When `DJANGO_MANAGE_MIGRATE=on`, it runs `collectstatic`, `migrate`, and `createcachetable`. If `DJANGO_SUPERUSER_USERNAME` and `DJANGO_SUPERUSER_PASSWORD` are set, it also runs `createsuperuser --noinput` — useful for first deploy without shell access; see commented examples in `.env.production.example`.
 
 See [docs/IMPLEMENTATION_GUIDE.md](../docs/IMPLEMENTATION_GUIDE.md) Step 6.3 and Step 9.2 for schema support and the full production checklist.
 


### PR DESCRIPTION
## Summary
- Document `DJANGO_MANAGE_MIGRATE` and optional `DJANGO_SUPERUSER_*` in `.env.production.example`
- Add a "Container entrypoint" section to `backend/README.md`

Closes #9